### PR TITLE
Fix wind load lengths units

### DIFF
--- a/generate_wind_loading.py
+++ b/generate_wind_loading.py
@@ -52,8 +52,8 @@ def _distribute(length: float, members: List[Dict[str, Any]], intensity: float,
             pos = 0.0
             continue
 
-        start = pos / 1000 if pos > 0 else None
-        end = (pos + seg) / 1000 if seg < m["length"] * 1000 or start is not None else None
+        start = pos if pos > 0 else None
+        end = (pos + seg) if seg < m["length"] * 1000 or start is not None else None
         _add_load(loads, m["name"], intensity, case, start, end)
 
         remaining -= seg


### PR DESCRIPTION
## Summary
- generate wind loads with load lengths in millimetres instead of metres

## Testing
- `python -m py_compile generate_wind_loading.py portal_frame_analysis.py user_input.py member_database.py member_strength_checks.py wind_loads.py`

------
https://chatgpt.com/codex/tasks/task_e_68503221f05883299e62f8e2c9c3cddb