### PR TITLE
Fix ProcessPool worker count

### DIFF
--- a/portal_frame_analysis.py
+++ b/portal_frame_analysis.py
@@ -281,7 +281,8 @@ def directional_search(primary, r_list, c_list, r_section_type, c_section_type,m
 
 
     acceptable = []
-    with ProcessPoolExecutor(max_workers=(num_core-4)) as ex:
+    workers = max(1, num_core - 4)
+    with ProcessPoolExecutor(max_workers=workers) as ex:
         futures = [ex.submit(analyze_combination, t) for t in tasks]
         for fut in as_completed(futures):
             result = fut.result()


### PR DESCRIPTION
## Summary
- use at least one worker for `directional_search`

## Testing
- `python -m py_compile portal_frame_analysis.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685f8b6fe18c83299911f7bb03571630